### PR TITLE
refactor render w/ .createElement(), .prepend()

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,19 +16,18 @@ function fetchTransactions() {
   )
 }
 
-// Want to refactor to be not so literal, replace innerHTML with prepend/append
 function renderTransactionCard(transaction) {
-  const card = `
-    <details>
-      <summary><b>
-        ${transaction.attributes.date} – ${transaction.attributes.recipient} – $${transaction.attributes.amount}
-      </b></summary>
-      <strong>Fund:</strong> ${transaction.attributes.fund.name}<br>
-      <strong>Contact:</strong> ${transaction.attributes.contact}<br>
-      <strong>Notes:</strong> ${transaction.attributes.notes}
-    </details>
-  `
-  document.getElementById('transaction-cards').innerHTML += card
+  const details = document.createElement('details')
+  const detailsContent = `
+    <summary><b>
+      ${transaction.attributes.date} – ${transaction.attributes.recipient} – $${transaction.attributes.amount}
+    </b></summary>
+    <strong>Fund:</strong> ${transaction.attributes.fund.name}<br>
+    <strong>Contact:</strong> ${transaction.attributes.contact}<br>
+    <strong>Notes:</strong> ${transaction.attributes.notes}
+    `
+  details.innerHTML = detailsContent
+  document.getElementById('transaction-cards').prepend(details)
 }
 
 function createTransactionHandler(e) {


### PR DESCRIPTION
Refactored renderTransactionCard with a .createElement() and then .prepend() them to parent element, eliminating the need for the .reverse on the sort_by in the TransactionsController. This also allows any just-created Transaction to appear at the top of the stack of Transactions for user's reassurance that it was saved, rather than at the end (and likely out of view).